### PR TITLE
Added additional ChoiceScript reserved words

### DIFF
--- a/home/.vim/syntax/choicescript.vim
+++ b/home/.vim/syntax/choicescript.vim
@@ -1,6 +1,8 @@
 " Vim syntax file
 " Language:     ChoiceScript
-" Maintainer:   Ben Hamill
+" Maintainer:   Tracy Canfield
+" Adds additional ChoiceScript reserved words to the syntax
+" file created by Ben Hamill
 
 if exists("b:current_syntax")
     finish
@@ -21,13 +23,22 @@ syn match choicescriptConditional '\*elseif'
 syn match choicescriptConditional '\*selectable_if'
 
 syn match choicescriptCommands '\*disable_reuse'
+syn match choicescriptCommands '\*allow_reuse'
+syn match choicescriptCommands '\*hide_reuse'
 syn match choicescriptCommands '\*set'
 syn match choicescriptCommands '\*temp'
+syn match choicescriptCommands '\*rand'
 syn match choicescriptCommands '\*page_break'
 syn match choicescriptCommands '\*line_break'
 syn match choicescriptCommands '\*return'
 syn match choicescriptCommands '\*stat_chart'
 syn match choicescriptCommands '\*finish'
+syn match choicescriptCommands '\*ending'
+syn match choicescriptCommands '\*achieve'
+syn match choicescriptCommands '\*achievement'
+syn match choicescriptCommands '\*image'
+syn match choicescriptCommands '\*input_text'
+syn match choicescriptCommands '\*input_number'
 
 syn match choicescriptSetup '\*title'
 syn match choicescriptSetup '\*author'


### PR DESCRIPTION
I've been using your Choicescript syntax highlighting file and found it very useful. I run into some ChoiceScript commands that weren't included - this is the expanded version of the file I've been using. Thank you for your work on this!

This version adds the following ChoiceScript commands:

*allow_reuse
*hide_reuse
*rand
*ending
*achieve
*achievement
*image
*input_text
*input_number